### PR TITLE
Compatibility with Monolite 0.7

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 80,
+  "semi": false,
+  "singleQuote": true
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = () => ({
+  transform: {
+    '.ts': require.resolve('ts-jest/preprocessor.js')
+  },
+  testRegex: '\\.test\\.ts$',
+  moduleDirectories: ['node_modules', 'src'],
+  moduleFileExtensions: ['ts', 'js', 'json']
+})

--- a/package.json
+++ b/package.json
@@ -16,20 +16,5 @@
     "jest": "^19.0.2",
     "ts-jest": "^19.0.10",
     "typescript": "^2.2.2"
-  },
-  "jest": {
-    "transform": {
-      ".ts": "<rootDir>/node_modules/ts-jest/preprocessor.js"
-    },
-    "testRegex": "\\.test\\.ts$",
-    "moduleDirectories": [
-      "node_modules",
-      "src"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "js",
-      "json"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc",
-    "test": "jest",
-    "dev": "jest --watch"
+    "test": "jest"
   },
   "devDependencies": {
     "@types/babel-core": "^6.7.14",
@@ -16,5 +15,8 @@
     "jest": "^19.0.2",
     "ts-jest": "^19.0.10",
     "typescript": "^2.2.2"
+  },
+  "peerDependencies": {
+    "monolite": "^0.7.0"
   }
 }

--- a/src/__tests__/plugin.spec.ts
+++ b/src/__tests__/plugin.spec.ts
@@ -74,3 +74,21 @@ set(state).set(['a', 'b', 'c'], 42).set(['a', 'd', 'e'], x => x + 1).end();`
 
   expect(result.code).toBe(expected)
 })
+
+it(`should throw if accessor does not return member expression`, () => {
+  const classicalSource = `
+import { set } from 'monolite';
+set(state, _ => something.b.c, 42)`
+
+  expect(() => transform(classicalSource, BABEL_OPTIONS)).toThrow(
+    'Monolite: Accessor function should return a subproperty of root'
+  )
+
+  const fluentSource = `
+import { set } from 'monolite';
+set(state).set(_ => something.b.c, 42)`
+
+  expect(() => transform(fluentSource, BABEL_OPTIONS)).toThrow(
+    'Monolite: Accessor function should return a subproperty of root'
+  )
+})

--- a/src/__tests__/plugin.spec.ts
+++ b/src/__tests__/plugin.spec.ts
@@ -11,16 +11,14 @@
 import { transform } from 'babel-core'
 import monolitePlugin from '..'
 
-
 it(`can take identifier accessors`, () => {
-
   const source = `
 import { set } from 'monolite';
-set(state, _ => _.a.b.c)(42);`
+set(state, _ => _.a.b.c, 42);`
 
   const expected = `
 import { set } from 'monolite';
-set(state, ['a', 'b', 'c'])(42);`
+set(state, ['a', 'b', 'c'], 42);`
 
   const result = transform(source, {
     plugins: [monolitePlugin]
@@ -28,17 +26,15 @@ set(state, ['a', 'b', 'c'])(42);`
 
   expect(result.code).toBe(expected)
 })
-
 
 it(`can take literal accessors`, () => {
-
   const source = `
 import { set } from 'monolite';
-set(state, _ => _['a'].b['c'])(42);`
+set(state, _ => _['a'].b['c'], 42);`
 
   const expected = `
 import { set } from 'monolite';
-set(state, ['a', 'b', 'c'])(42);`
+set(state, ['a', 'b', 'c'], 42);`
 
   const result = transform(source, {
     plugins: [monolitePlugin]
@@ -47,16 +43,14 @@ set(state, ['a', 'b', 'c'])(42);`
   expect(result.code).toBe(expected)
 })
 
-
 it(`can take uncomputed identifier accessors`, () => {
-
   const source = `
 import { set } from 'monolite';
-set(state, _ => _['a'].b[c])(42);`
+set(state, _ => _['a'].b[c], 42);`
 
   const expected = `
 import { set } from 'monolite';
-set(state, ['a', 'b', c])(42);`
+set(state, ['a', 'b', c], 42);`
 
   const result = transform(source, {
     plugins: [monolitePlugin]

--- a/src/__tests__/plugin.spec.ts
+++ b/src/__tests__/plugin.spec.ts
@@ -11,6 +11,10 @@
 import { transform } from 'babel-core'
 import monolitePlugin from '..'
 
+const BABEL_OPTIONS = {
+  plugins: [monolitePlugin]
+}
+
 it(`can take identifier accessors`, () => {
   const source = `
 import { set } from 'monolite';
@@ -36,9 +40,7 @@ set(state, _ => _['a'].b['c'], 42);`
 import { set } from 'monolite';
 set(state, ['a', 'b', 'c'], 42);`
 
-  const result = transform(source, {
-    plugins: [monolitePlugin]
-  })
+  const result = transform(source, BABEL_OPTIONS)
 
   expect(result.code).toBe(expected)
 })
@@ -55,6 +57,20 @@ set(state, ['a', 'b', c], 42);`
   const result = transform(source, {
     plugins: [monolitePlugin]
   })
+
+  expect(result.code).toBe(expected)
+})
+
+it(`can transform fluent-style set`, () => {
+  const source = `
+import { set } from 'monolite';
+set(state).set(_ => _.a.b.c, 42).set(_ => _.a.d.e, x => x + 1).end();`
+
+  const expected = `
+import { set } from 'monolite';
+set(state).set(['a', 'b', 'c'], 42).set(['a', 'd', 'e'], x => x + 1).end();`
+
+  const result = transform(source, BABEL_OPTIONS)
 
   expect(result.code).toBe(expected)
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,85 +12,84 @@ import { Types, BabelPlugin } from './types'
 import { NodePath } from 'babel-traverse'
 import { Expression, CallExpression, MemberExpression } from 'babel-types'
 
-const getAccessorChainFromFunction =
-  (types: Types, expr: MemberExpression) => {
+const getAccessorChainFromFunction = (types: Types, expr: MemberExpression) => {
+  const chain: Expression[] =
+    expr.object.type === 'MemberExpression'
+      ? getAccessorChainFromFunction(types, expr.object)
+      : []
 
-    const chain: Expression[] =
-      expr.object.type === 'MemberExpression'
-        ? getAccessorChainFromFunction(types, expr.object)
-        : []
-
-    if (types.isIdentifier(expr.property))
-      chain.push(
-        expr.computed === true
-          ? expr.property
-          : types.stringLiteral(expr.property.name)
-      )
-    else if (types.isLiteral(expr.property))
-      chain.push(expr.property)
-
-    return chain
+  if (types.isIdentifier(expr.property)) {
+    chain.push(
+      expr.computed === true
+        ? expr.property
+        : types.stringLiteral(expr.property.name)
+    )
+  } else if (types.isLiteral(expr.property)) {
+    chain.push(expr.property)
   }
 
-const isImportedFromMonolite =
-  (path: NodePath<CallExpression>): boolean => {
+  return chain
+}
 
-    if (path.node.callee.type !== 'Identifier')
-      return false
-
-    if (path.node.callee.name !== 'set')
-      return false
-
-    // Check set is imported from a module
-    const setDeclaration = path.scope.getBinding('set')
-
-    // set is a global variable
-    if (setDeclaration === undefined)
-      return false
-
-    // set is not imported from a module
-    if (setDeclaration.kind !== 'module')
-      return false
-
-    return true
+const isImportedFromMonolite = (path: NodePath<CallExpression>): boolean => {
+  if (path.node.callee.type !== 'Identifier') {
+    return false
   }
+
+  if (path.node.callee.name !== 'set') {
+    return false
+  }
+
+  // Check set is imported from a module
+  const setDeclaration = path.scope.getBinding('set')
+
+  // set is a global variable
+  if (setDeclaration === undefined) {
+    return false
+  }
+
+  // set is not imported from a module
+  if (setDeclaration.kind !== 'module') {
+    return false
+  }
+
+  return true
+}
 
 const monolitePlugin: BabelPlugin = ({ types }) => ({
   visitor: {
     CallExpression(path) {
-
-      if (!isImportedFromMonolite(path))
+      if (!isImportedFromMonolite(path)) {
         return
+      }
 
-      const accessorFunction = path.node.arguments[1]
+      const [, accessorFunction, valueTransformer] = path.node.arguments
 
-      if (accessorFunction === undefined)
+      if (
+        typeof accessorFunction === 'undefined' ||
+        typeof valueTransformer === 'undefined'
+      ) {
         return
+      }
 
-      if (accessorFunction.type !== 'ArrowFunctionExpression')
+      if (
+        accessorFunction.type !== 'ArrowFunctionExpression' ||
+        accessorFunction.params.length !== 1 ||
+        accessorFunction.type !== 'ArrowFunctionExpression' ||
+        accessorFunction.body.type !== 'MemberExpression'
+      ) {
         return
-
-      if (accessorFunction.params.length !== 1)
-        return
-
-      if (accessorFunction.type !== 'ArrowFunctionExpression')
-        return
-
-      if (accessorFunction.body.type !== 'MemberExpression')
-        return
+      }
 
       path.replaceWith(
-        types.callExpression(
-          path.node.callee,
-          [
-            path.node.arguments[0],
-            types.arrayExpression(
-              getAccessorChainFromFunction(types, accessorFunction.body)
-            )
-          ]
-        )
+        types.callExpression(path.node.callee, [
+          path.node.arguments[0],
+          types.arrayExpression(
+            getAccessorChainFromFunction(types, accessorFunction.body)
+          ),
+          valueTransformer
+        ])
       )
-
     }
   }
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,13 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5",
-    "noImplicitAny": true,
+    "target": "es2015",
+    "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "removeComments": true,
     "sourceMap": false,
     "rootDir": "src",
     "outDir": "lib"
-  },
-  "files": [
-    "src/index.ts"
-  ]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1676,6 +1676,10 @@ mkdirp@0.5.x, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+monolite@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/monolite/-/monolite-0.7.0.tgz#b406e714f56dd5f1c48961450fbd716f8841cb48"
+
 ms@0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.3.tgz#708155a5e44e33f5fd0fc53e81d0d40a91be1fff"


### PR DESCRIPTION
- Add support for fluent-style `set`.
- Add accessor function checks (should always return a member of the root)